### PR TITLE
Add support for outputting via <img> and <object> tags

### DIFF
--- a/layouts/partials/kroki/output.html
+++ b/layouts/partials/kroki/output.html
@@ -34,6 +34,15 @@
     {{ with $attrs }}{{ partial "kroki/functions/attrs2str" . | safeHTMLAttr }}{{ end }}
     type="image/svg+xml"
     src="{{ $svg.RelPermalink }}" />
+{{- else if eq $output "img" }}
+  <img
+    {{ with $attrs }}{{ partial "kroki/functions/attrs2str" . | safeHTMLAttr }}{{ end }}
+    src="{{ $svg.RelPermalink }}" />
+{{- else if eq $output "object" }}
+  <object
+    {{ with $attrs }}{{ partial "kroki/functions/attrs2str" . | safeHTMLAttr }}{{ end }}
+    type="image/svg+xml"
+    data="{{ $svg.RelPermalink }}" />
 {{- else }}
   {{- warnf "[kroki] unknown output: %s" $output }}
 {{- end }}


### PR DESCRIPTION
I'm not certain whether you're interested in this contribution, but I needed to be able to attach the generated SVGs via img and object tags due to policies that others have imposed upon me.

The attached change just adds support for options for "img" and "object" for the output parameter, which really just substitutes the tag name and modifies the associated attributes accordingly.

If you feel this isn't useful functionality then please feel free to close out this pull request and ignore it. Either way thanks for an awesome Hugo module :)